### PR TITLE
Corrige enlace de precios de gasolineras del README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gasolinapp
 
 ## Idea inicial
-La idea inicial consiste en comparar los precios de las gasolineras de una misma ciudad y seleccionar las opciones de combustible más baratas, apoyándose en los datos de .[Precio de carburantes en las gasolineras españolas].https://sede.serviciosmin.gob.es/es-es/datosabiertos/catalogo/precios-carburantes para ello.
+La idea inicial consiste en comparar los precios de las gasolineras de una misma ciudad y seleccionar las opciones de combustible más baratas, apoyándose en los datos de [precio de carburantes en las gasolineras españolas](https://sede.serviciosmin.gob.es/es-es/datosabiertos/catalogo/precios-carburantes) para ello.
 
 ## Descripción
 Repositorio para proyecto de la asignatura Infraestructura Virtual de la UGR.


### PR DESCRIPTION
Me equivoqué con la sintaxis de los enlaces en los README de Github.